### PR TITLE
Improved Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM golang as build
+RUN go get github.com/mindprince/nvidia_gpu_prometheus_exporter
+
+FROM nvidia/cuda:9.0-base
+
+RUN mkdir /exporter
+WORKDIR /exporter
+
+COPY --from=build /go/bin/nvidia_gpu_prometheus_exporter .
+
+CMD ./nvidia_gpu_prometheus_exporter
+EXPOSE 9445


### PR DESCRIPTION
Images built from this Dockerfile don't require access to the NVML library on the host machine, as they're based on the official CUDA 9.0 base image. The resulting image is less than 150 MB. Works under Nvidia Container Runtime (AKA Nvidia Docker).