### PR TITLE
Add disable fanspeed switch

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,6 @@ RUN go get github.com/mindprince/nvidia_gpu_prometheus_exporter
 
 FROM ubuntu:18.04
 COPY --from=build /go/bin/nvidia_gpu_prometheus_exporter /
-CMD /nvidia_gpu_prometheus_exporter
 ENV NVIDIA_VISIBLE_DEVICES=all
 EXPOSE 9445
+ENTRYPOINT ["/nvidia_gpu_prometheus_exporter"]

--- a/main.go
+++ b/main.go
@@ -18,6 +18,7 @@ const (
 
 var (
 	addr = flag.String("web.listen-address", ":9445", "Address to listen on for web interface and telemetry.")
+	disableFanSpeed = flag.Bool("disable-fanspeed", false, "Disable fanspeed metric")
 
 	labels = []string{"minor_number", "uuid", "name"}
 )
@@ -179,11 +180,13 @@ func (c *Collector) Collect(ch chan<- prometheus.Metric) {
 			c.temperature.WithLabelValues(minor, uuid, name).Set(float64(temperature))
 		}
 
-		fanSpeed, err := dev.FanSpeed()
-		if err != nil {
-			log.Printf("FanSpeed() error: %v", err)
-		} else {
-			c.fanSpeed.WithLabelValues(minor, uuid, name).Set(float64(fanSpeed))
+		if !*disableFanSpeed {
+			fanSpeed, err := dev.FanSpeed()
+			if err != nil {
+				log.Printf("FanSpeed() error: %v", err)
+			} else {
+				c.fanSpeed.WithLabelValues(minor, uuid, name).Set(float64(fanSpeed))
+			}
 		}
 	}
 	c.usedMemory.Collect(ch)


### PR DESCRIPTION
This is a different take on:

https://github.com/mindprince/nvidia_gpu_prometheus_exporter/pull/11

It makes disabling the fanspeed metric configurable with the `-disable-fanspeed` switch.

I've also updated the Dockerfile to use the ENTRYPOINT directive the switch can be used like this:

```
sudo docker run -p 9445:9445 -it --runtime=nvidia mindprince/nvidia_gpu_prometheus_exporter -h
sudo docker run -p 9445:9445 -it --runtime=nvidia mindprince/nvidia_gpu_prometheus_exporter -disable-fanspeed
```